### PR TITLE
Improve npm package installation security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,17 +19,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
           cache: npm
 
+      - name: Update npm
+        run: npm install -g npm@11 --registry=https://registry.npmjs.org
+
       - name: Set package version
-        uses: microbit-foundation/npm-package-versioner-action@v1
+        uses: microbit-foundation/npm-package-versioner-action@v3
 
       - name: Install dependencies
         run: npm ci
@@ -37,7 +40,7 @@ jobs:
       - name: Build library and standalone
         run: npm run build
 
-      - run: npm publish --access public
+      - run: npm publish --access public --allow-directory=all
         if: github.event_name == 'release' && github.event.action == 'created'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,13 @@
+min-release-age=7
+min-release-age-exclude[]=@microbit/*
+min-release-age-exclude[]=@microbit-foundation/*
+
+# root here means this project's package.json
+allow-git=root
+allow-remote=root
+allow-file=root
+allow-directory=root
+
+strict-allow-scripts=true
+
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@microbit-foundation/keyosd",
+  "name": "@microbit/keyosd",
   "version": "0.0.0-local",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@microbit-foundation/keyosd",
+      "name": "@microbit/keyosd",
       "version": "0.0.0-local",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "vite": "^5.0.8",
     "vite-plugin-dts": "^3.7.0"
   },
+  "allowScripts": {
+    "esbuild": true,
+    "fsevents": true
+  },
   "keywords": [
     "keystroke",
     "osd",


### PR DESCRIPTION
1. .npmrc (new) — added exactly as specified: min-release-age=7 with @microbit/* and @microbit-foundation/* excluded, allow-*=root, strict-allow-scripts=true, engine-strict=true.

2. engines in package.json is not pinned as it is a public package.

3. package.json — allowScripts added. strict-allow-scripts=true means the build breaks without this. The lockfile has exactly two packages with install scripts, both transitive deps of vite:

"allowScripts": {
  "esbuild": true,
  "fsevents": true
}

4. .github/workflows/build.yml — checkout@v4→v7, setup-node@v4→v6, node 20.x→24.x, added the npm install -g npm@11 step before the versioner, versioner action v1→v3, and npm publish --access public --allow-directory=all.